### PR TITLE
changed delete to use req.params

### DIFF
--- a/api/db/services/diagrams.js
+++ b/api/db/services/diagrams.js
@@ -33,7 +33,7 @@ module.exports = {
   },
   deleteDiagram: (req, res, next) => {
     try {
-      const { diagramId } = req.body;
+      const { diagramId } = req.params;
       Diagram.findOneAndDelete({ _id: diagramId })
         .then((data) => {
           res.locals.diagram = data;

--- a/api/routes/diagrams.js
+++ b/api/routes/diagrams.js
@@ -16,7 +16,7 @@ router.get('/:user',
     diagrams: res.locals.diagrams
   }))
 
-router.delete('/',
+router.delete('/:diagramId',
   diagramController.deleteDiagram,
   (req, res) => res.status(200).json({
     diagram: res.locals.diagram


### PR DESCRIPTION
**Issue:** DELETE request for diagrams was using a request body. This is not best practice.

**Fix:** Changed /diagrams DELETE endpoint to use request parameters rather than a request body