### PR TITLE
returning diagrams after delete

### DIFF
--- a/api/db/services/diagrams.js
+++ b/api/db/services/diagrams.js
@@ -21,9 +21,8 @@ module.exports = {
   },
   getAllDiagrams: (req, res, next) => {
     try {
-      let user = req.params.user || res.locals.user._id
-      console.log(user)
-      // const { user } = req.params || res.locals.user._id;
+      let user = req.params.user || res.locals.diagram.user
+      if (!user) return res.status(400).send('missing necessary data');
       Diagram.find({ user: user })
         .then((data) => {
           res.locals.diagrams = data
@@ -36,9 +35,12 @@ module.exports = {
   deleteDiagram: (req, res, next) => {
     try {
       const { diagramId } = req.params;
+      console.log('diagramId in deleteDiagram: ', diagramId)
       Diagram.findOneAndDelete({ _id: diagramId })
         .then((data) => {
+          if (!data) return res.status(204).send('no data found)')
           res.locals.diagram = data;
+          console.log(data);
           return next();
         })
     } catch(err) {

--- a/api/routes/diagrams.js
+++ b/api/routes/diagrams.js
@@ -18,8 +18,9 @@ router.get('/:user',
 
 router.delete('/:diagramId',
   diagramController.deleteDiagram,
+  diagramController.getAllDiagrams,
   (req, res) => res.status(200).json({
-    diagram: res.locals.diagram
+    diagrams: res.locals.diagrams
   }));
 
 router.put('/favorite/:diagramId',


### PR DESCRIPTION
**Issue:** 
- Delete requests only returned the deleted record and not a full list of the user's arrays
- This made updating the diagram list immediately on the frontend difficult 

**In this PR:** 
- Added get all diagrams middleware function to the delete endpoint 